### PR TITLE
Open method does not correctly free allocated memory, calling C.CString instead of using cFilePath

### DIFF
--- a/mediainfo.go
+++ b/mediainfo.go
@@ -87,7 +87,7 @@ func Open(filePath string) (*File, error) {
     cFilePath := C.CString(filePath)
     defer C.free(unsafe.Pointer(cFilePath))
 
-    handle := C.OpenFile(C.CString(filePath))
+    handle := C.OpenFile(cFilePath)
     if handle == nil {
         return nil, errors.New("Cannot open file.")
     }


### PR DESCRIPTION
While using go-mediainfo to read many files, I experienced a leak due to not correctly freeing the string passed to the OpenFile call. It looks like the variable was set up and not used.

I tested the change locally against the same dataset, and have not experienced a failure in the same codepath since.